### PR TITLE
Update dependencies

### DIFF
--- a/cere01/Cargo.toml
+++ b/cere01/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["team@cere.io"]
 edition = "2018"
 
 [dependencies]
-ink_primitives = { version = "3.0.0-rc1", default-features = false }
-ink_metadata = { version = "3.0.0-rc1", default-features = false, features = ["derive"], optional = true }
-ink_env = { version = "3.0.0-rc1", default-features = false }
-ink_storage = { version = "3.0.0-rc1", default-features = false }
-ink_lang = { version = "3.0.0-rc1", default-features = false }
-ink_prelude = { version = "3.0.0-rc2", default-features = false }
+ink_primitives = { version = "3.0.0-rc3", default-features = false }
+ink_metadata = { version = "3.0.0-rc3", default-features = false, features = ["derive"], optional = true }
+ink_env = { version = "3.0.0-rc3", default-features = false }
+ink_storage = { version = "3.0.0-rc3", default-features = false }
+ink_lang = { version = "3.0.0-rc3", default-features = false }
+ink_prelude = { version = "3.0.0-rc3", default-features = false }
 
-scale = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"] }
-scale-info = { version = "0.4", default-features = false, features = ["derive"], optional = true }
+scale = { package = "parity-scale-codec", version = "2.1", default-features = false, features = ["derive"] }
+scale-info = { version = "0.6.0", default-features = false, features = ["derive"], optional = true }
 
 [lib]
 name = "cere01"
@@ -36,8 +36,7 @@ std = [
 ink-as-dependency = []
 
 [workspace]
-members = [
-]
+members = []
 exclude = [
 	".ink"
 ]


### PR DESCRIPTION
We need to update the dependencies so that smart contracts compile without errors.

The list of dependencies is the same as the one created when running `cargo contract new project`.

It was tested on Apple M1 processor (nightly-aarch64-apple-darwin) and also using linux docker container.

Working versions: from `nightly-2021-01-31` to the latest version of nightly (2021-05-24)