### PR TITLE
DDN status tracking

### DIFF
--- a/cere02/ddc/tests.rs
+++ b/cere02/ddc/tests.rs
@@ -1597,7 +1597,7 @@ fn default_ddn_status_works() {
 }
 
 #[ink::test]
-fn report_metrics_update_ddn_status_works() {
+fn report_metrics_updates_ddn_status_works() {
     let mut contract = make_contract();
     let accounts = default_accounts::<DefaultEnvironment>().unwrap();
 

--- a/cere02/ddc/tests.rs
+++ b/cere02/ddc/tests.rs
@@ -1346,168 +1346,168 @@ fn report_ddn_status_works() {
 
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 0,
             reference_timestamp: 0,
             last_timestamp: 0,
-        }
+        })
     );
 
     set_balance(now_account, 4);
     contract.report_ddn_status(p2p_id.clone(), true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 0,
             reference_timestamp: 0,
             last_timestamp: 4,
-        }
+        })
     );
 
     set_balance(now_account, 6);
     contract.report_ddn_status(p2p_id.clone(), true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 0,
             reference_timestamp: 0,
             last_timestamp: 6,
-        }
+        })
     );
 
     set_balance(now_account, 8);
     contract.report_ddn_status(p2p_id.clone(), false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: false,
             total_downtime: 0,
             reference_timestamp: 0,
             last_timestamp: 8,
-        }
+        })
     );
 
     set_balance(now_account, 10);
     contract.report_ddn_status(p2p_id.clone(), false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: false,
             total_downtime: 2,
             reference_timestamp: 0,
             last_timestamp: 10,
-        }
+        })
     );
 
     set_balance(now_account, 12);
     contract.report_ddn_status(p2p_id.clone(), true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 4,
             reference_timestamp: 0,
             last_timestamp: 12,
-        }
+        })
     );
 
     set_balance(now_account, 15);
     contract.report_ddn_status(p2p_id.clone(), true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 4,
             reference_timestamp: 0,
             last_timestamp: 15,
-        }
+        })
     );
 
     set_balance(now_account, 18);
     contract.report_ddn_status(p2p_id.clone(), false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: false,
             total_downtime: 4,
             reference_timestamp: 0,
             last_timestamp: 18,
-        }
+        })
     );
 
     set_balance(now_account, 25);
     contract.report_ddn_status(p2p_id.clone(), true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 11,
             reference_timestamp: 0,
             last_timestamp: 25,
-        }
+        })
     );
 
     set_balance(now_account, 30);
     contract.report_ddn_status(p2p_id.clone(), false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: false,
             total_downtime: 11,
             reference_timestamp: 0,
             last_timestamp: 30,
-        }
+        })
     );
 
     set_balance(now_account, 34);
     contract.report_ddn_status(p2p_id.clone(), false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: false,
             total_downtime: 15,
             reference_timestamp: 0,
             last_timestamp: 34,
-        }
+        })
     );
 
     set_balance(now_account, 42);
     contract.report_ddn_status(p2p_id.clone(), false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: false,
             total_downtime: 23,
             reference_timestamp: 0,
             last_timestamp: 42,
-        }
+        })
     );
 
     set_balance(now_account, 44);
     contract.report_ddn_status(p2p_id.clone(), true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 25,
             reference_timestamp: 0,
             last_timestamp: 44,
-        }
+        })
     );
 
     set_balance(now_account, 50);
     contract.report_ddn_status(p2p_id.clone(), true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
-        DDNStatus {
+        Ok(DDNStatus {
             is_online: true,
             total_downtime: 25,
             reference_timestamp: 0,
             last_timestamp: 50,
-        }
+        })
     );
 }
 

--- a/cere02/ddc/tests.rs
+++ b/cere02/ddc/tests.rs
@@ -1235,7 +1235,7 @@ fn add_ddc_node_only_owner_works() {
     let mut contract = make_contract();
     let accounts = default_accounts::<DefaultEnvironment>().unwrap();
     let p2p_id = String::from("test_p2p_id");
-    let url = String::from("ws://localhost:9944");
+    let url = String::from("test_url");
 
     // Should be an owner
     set_caller(accounts.charlie);
@@ -1246,9 +1246,9 @@ fn add_ddc_node_only_owner_works() {
 fn add_ddc_node_works() {
     let mut contract = make_contract();
     let p2p_id = String::from("test_p2p_id");
-    let url = String::from("ws://localhost:9944");
+    let url = String::from("test_url");
 
-    // Add DDC node
+    // Add DDC node to the list
     contract.add_ddc_node(p2p_id.clone(), url.clone()).unwrap();
 
     // Should be in the list
@@ -1258,6 +1258,17 @@ fn add_ddc_node_works() {
             p2p_id: p2p_id.clone(),
             url: url.clone()
         },]
+    );
+
+    // Should add the default DDN status
+    assert_eq!(
+        contract.get_ddn_status(p2p_id.clone()).unwrap(),
+        DDNStatus {
+            is_online: true,
+            total_downtime: 0,
+            reference_timestamp: 0,
+            last_timestamp: 0,
+        }
     );
 
     // Should emit event
@@ -1276,15 +1287,40 @@ fn add_ddc_node_works() {
 }
 
 #[ink::test]
+fn add_ddn_node_update_url_works() {
+    let mut contract = make_contract();
+    let p2p_id = String::from("test_p2p_id");
+    let url = String::from("test_url");
+    let new_url = String::from("test_url_new");
+
+    // Add DDC node to the list
+    contract.add_ddc_node(p2p_id.clone(), url.clone()).unwrap();
+
+    // Update DDC node url
+    contract
+        .add_ddc_node(p2p_id.clone(), new_url.clone())
+        .unwrap();
+
+    // Get the list of DDC nodes
+    assert_eq!(
+        contract.get_all_ddc_nodes(),
+        vec![DDCNode {
+            p2p_id,
+            url: new_url
+        }]
+    );
+}
+
+#[ink::test]
 fn is_ddc_node_works() {
     let mut contract = make_contract();
     let p2p_id = String::from("test_p2p_id");
-    let url = String::from("ws://localhost:9944");
+    let url = String::from("test_url");
 
     // Return false if not added
     assert_eq!(contract.is_ddc_node(p2p_id.clone()), false);
 
-    // Add DDC node
+    // Add DDC node to the list
     contract.add_ddc_node(p2p_id.clone(), url.clone()).unwrap();
 
     // Should be in the list
@@ -1306,9 +1342,9 @@ fn remove_ddc_node_only_owner_works() {
 fn remove_ddc_node_works() {
     let mut contract = make_contract();
     let p2p_id = String::from("test_p2p_id");
-    let url = String::from("ws://localhost:9944");
+    let url = String::from("test_url");
 
-    // Add DDC node
+    // Add DDC node to the list
     contract.add_ddc_node(p2p_id.clone(), url.clone()).unwrap();
 
     // Remove DDC node
@@ -1333,53 +1369,50 @@ fn remove_ddc_node_works() {
 // ---- DDN Statuses ----
 
 #[ink::test]
-fn report_ddn_status_works() {
+fn set_ddn_status_not_found_works() {
     let mut contract = make_contract();
-    let accounts = default_accounts::<DefaultEnvironment>().unwrap();
+    let p2p_id = String::from("test_p2p_id");
 
-    let p2p_id = String::from("12D3KooWPfi9EtgoZHFnHh1at85mdZJtj7L8n94g6LFk6e8EEk2b");
-    let url = String::from("localhost");
-    let now_account = AccountId::from([0x05; 32]);
-
-    contract.add_ddc_node(p2p_id.clone(), url).unwrap();
-    contract.add_reporter(accounts.alice).unwrap();
-
+    // DDC node should be in the list
     assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
-        Ok(DDNStatus {
-            is_online: true,
-            total_downtime: 0,
-            reference_timestamp: 0,
-            last_timestamp: 0,
-        })
+        contract.set_ddn_status(p2p_id, 4, true),
+        Err(Error::DDNNotFound)
     );
+}
 
-    set_balance(now_account, 4);
-    contract.report_ddn_status(p2p_id.clone(), true).unwrap();
+#[ink::test]
+fn set_ddn_status_works() {
+    let mut contract = make_contract();
+    let p2p_id = String::from("test_p2p_id");
+    let url = String::from("test_url");
+
+    // Add DDC node to the list
+    contract.add_ddc_node(p2p_id.clone(), url).unwrap();
+
+    // Calculations should work
+    contract.set_ddn_status(p2p_id.clone(), 4, true).unwrap();
     assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
-        Ok(DDNStatus {
+        contract.get_ddn_status(p2p_id.clone()).unwrap(),
+        DDNStatus {
             is_online: true,
             total_downtime: 0,
             reference_timestamp: 0,
             last_timestamp: 4,
-        })
+        }
     );
 
-    set_balance(now_account, 6);
-    contract.report_ddn_status(p2p_id.clone(), true).unwrap();
+    contract.set_ddn_status(p2p_id.clone(), 6, true).unwrap();
     assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
-        Ok(DDNStatus {
+        contract.get_ddn_status(p2p_id.clone()).unwrap(),
+        DDNStatus {
             is_online: true,
             total_downtime: 0,
             reference_timestamp: 0,
             last_timestamp: 6,
-        })
+        }
     );
 
-    set_balance(now_account, 8);
-    contract.report_ddn_status(p2p_id.clone(), false).unwrap();
+    contract.set_ddn_status(p2p_id.clone(), 8, false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
         Ok(DDNStatus {
@@ -1390,8 +1423,7 @@ fn report_ddn_status_works() {
         })
     );
 
-    set_balance(now_account, 10);
-    contract.report_ddn_status(p2p_id.clone(), false).unwrap();
+    contract.set_ddn_status(p2p_id.clone(), 10, false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
         Ok(DDNStatus {
@@ -1402,8 +1434,7 @@ fn report_ddn_status_works() {
         })
     );
 
-    set_balance(now_account, 12);
-    contract.report_ddn_status(p2p_id.clone(), true).unwrap();
+    contract.set_ddn_status(p2p_id.clone(), 12, true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
         Ok(DDNStatus {
@@ -1414,20 +1445,7 @@ fn report_ddn_status_works() {
         })
     );
 
-    set_balance(now_account, 15);
-    contract.report_ddn_status(p2p_id.clone(), true).unwrap();
-    assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
-        Ok(DDNStatus {
-            is_online: true,
-            total_downtime: 4,
-            reference_timestamp: 0,
-            last_timestamp: 15,
-        })
-    );
-
-    set_balance(now_account, 18);
-    contract.report_ddn_status(p2p_id.clone(), false).unwrap();
+    contract.set_ddn_status(p2p_id.clone(), 18, false).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
         Ok(DDNStatus {
@@ -1438,8 +1456,7 @@ fn report_ddn_status_works() {
         })
     );
 
-    set_balance(now_account, 25);
-    contract.report_ddn_status(p2p_id.clone(), true).unwrap();
+    contract.set_ddn_status(p2p_id.clone(), 25, true).unwrap();
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
         Ok(DDNStatus {
@@ -1449,64 +1466,173 @@ fn report_ddn_status_works() {
             last_timestamp: 25,
         })
     );
+}
 
-    set_balance(now_account, 30);
-    contract.report_ddn_status(p2p_id.clone(), false).unwrap();
+#[ink::test]
+fn set_ddn_status_unexpected_timestamp_works() {
+    let mut contract = make_contract();
+    let p2p_id = String::from("test_p2p_id");
+    let url = String::from("test_url");
+
+    // Add DDC node to the list
+    contract.add_ddc_node(p2p_id.clone(), url).unwrap();
+
+    // Set status for a timestamp
+    assert_eq!(contract.set_ddn_status(p2p_id.clone(), 10, true), Ok(()));
+
+    // Specified timestamp must be greater than the last one
+    assert_eq!(
+        contract.set_ddn_status(p2p_id, 8, true),
+        Err(Error::UnexpectedTimestamp)
+    );
+}
+
+#[ink::test]
+fn get_ddn_status_not_found_works() {
+    let contract = make_contract();
+    let p2p_id = String::from("test_p2p_id");
+
+    // Should return an error if not found
+    assert_eq!(contract.get_ddn_status(p2p_id), Err(Error::DDNNotFound));
+}
+
+#[ink::test]
+fn get_ddn_status_works() {
+    let mut contract = make_contract();
+    let p2p_id = String::from("test_p2p_id");
+    let url = String::from("test_url");
+
+    // Add DDC node to the list
+    contract.add_ddc_node(p2p_id.clone(), url).unwrap();
+
+    // Set new status
+    contract.set_ddn_status(p2p_id.clone(), 2, false).unwrap();
+
+    // Get updated status
+    assert_eq!(
+        contract.get_ddn_status(p2p_id),
+        Ok(DDNStatus {
+            is_online: false,
+            total_downtime: 0,
+            reference_timestamp: 0,
+            last_timestamp: 2,
+        })
+    );
+}
+
+#[ink::test]
+fn report_ddn_status_only_reporter_works() {
+    let mut contract = make_contract();
+    let p2p_id = String::from("test_p2p_id");
+
+    // Caller should be a reporter
+    assert_eq!(
+        contract.report_ddn_status(p2p_id.clone(), true),
+        Err(Error::OnlyReporter)
+    );
+}
+
+#[ink::test]
+fn report_ddn_status_not_found_works() {
+    let mut contract = make_contract();
+    let accounts = default_accounts::<DefaultEnvironment>().unwrap();
+    let p2p_id = String::from("test_p2p_id");
+
+    // Make admin a reporter
+    contract.add_reporter(accounts.alice).unwrap();
+
+    // Should report only for listed DDC node
+    assert_eq!(
+        contract.report_ddn_status(p2p_id.clone(), true),
+        Err(Error::DDNNotFound)
+    );
+}
+
+#[ink::test]
+fn report_ddn_status_works() {
+    let mut contract = make_contract();
+    let accounts = default_accounts::<DefaultEnvironment>().unwrap();
+    let p2p_id = String::from("test_p2p_id");
+    let url = String::from("test_url");
+
+    // Make admin a reporter
+    contract.add_reporter(accounts.alice).unwrap();
+
+    // Add DDC node to the list
+    contract.add_ddc_node(p2p_id.clone(), url).unwrap();
+
+    // Should return Ok
+    assert_eq!(contract.report_ddn_status(p2p_id.clone(), true), Ok(()));
+}
+
+#[ink::test]
+fn default_ddn_status_works() {
+    let mut contract = make_contract();
+    let p2p_id = String::from("test_p2p_id");
+    let url = String::from("test_url");
+    let new_url = String::from("test_url_new");
+
+    // Add DDC node to the list
+    contract.add_ddc_node(p2p_id.clone(), url.clone()).unwrap();
+
+    // Set new status
+    contract.set_ddn_status(p2p_id.clone(), 2, false).unwrap();
+    contract.set_ddn_status(p2p_id.clone(), 6, false).unwrap();
+
+    // Repeat adding DDC node (update url)
+    contract
+        .add_ddc_node(p2p_id.clone(), new_url.clone())
+        .unwrap();
+
+    // Get updated status
     assert_eq!(
         contract.get_ddn_status(p2p_id.clone()),
         Ok(DDNStatus {
             is_online: false,
-            total_downtime: 11,
+            total_downtime: 4,
             reference_timestamp: 0,
-            last_timestamp: 30,
+            last_timestamp: 6,
         })
     );
+}
 
-    set_balance(now_account, 34);
-    contract.report_ddn_status(p2p_id.clone(), false).unwrap();
-    assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
-        Ok(DDNStatus {
-            is_online: false,
-            total_downtime: 15,
-            reference_timestamp: 0,
-            last_timestamp: 34,
-        })
-    );
+#[ink::test]
+fn report_metrics_update_ddn_status_works() {
+    let mut contract = make_contract();
+    let accounts = default_accounts::<DefaultEnvironment>().unwrap();
 
-    set_balance(now_account, 42);
-    contract.report_ddn_status(p2p_id.clone(), false).unwrap();
-    assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
-        Ok(DDNStatus {
-            is_online: false,
-            total_downtime: 23,
-            reference_timestamp: 0,
-            last_timestamp: 42,
-        })
-    );
+    let first_day = 1000;
 
-    set_balance(now_account, 44);
-    contract.report_ddn_status(p2p_id.clone(), true).unwrap();
+    let today_ms = (first_day + 17) * MS_PER_DAY;
+    let ddn_id = b"12D3KooWPfi9EtgoZHFnHh1at85mdZJtj7L8n94g6LFk6e8EEk2b".to_vec();
+    let stored_bytes = 99;
+    let requests = 999;
+
+    let p2p_id = String::from_utf8(ddn_id.clone()).unwrap();
+    let url = String::from("test_url");
+
+    // Add DDC node to the list
+    contract.add_ddc_node(p2p_id.clone(), url).unwrap();
+
+    // Set new DDC node status
+    contract.set_ddn_status(p2p_id.clone(), 0, false).unwrap();
+
+    // Make admin a reporter
+    contract.add_reporter(accounts.alice).unwrap();
+
+    // Report DDN metrics
+    contract
+        .report_metrics_ddn(ddn_id.clone(), today_ms, stored_bytes, requests)
+        .unwrap();
+
+    // DDN status should be online
     assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
+        contract.get_ddn_status(p2p_id),
         Ok(DDNStatus {
             is_online: true,
-            total_downtime: 25,
+            total_downtime: 0,
             reference_timestamp: 0,
-            last_timestamp: 44,
-        })
-    );
-
-    set_balance(now_account, 50);
-    contract.report_ddn_status(p2p_id.clone(), true).unwrap();
-    assert_eq!(
-        contract.get_ddn_status(p2p_id.clone()),
-        Ok(DDNStatus {
-            is_online: true,
-            total_downtime: 25,
-            reference_timestamp: 0,
-            last_timestamp: 50,
+            last_timestamp: 0,
         })
     );
 }
@@ -1577,12 +1703,10 @@ fn report_metrics_ddn_works() {
     let stored_bytes = 99;
     let requests = 999;
 
-    contract
-        .add_ddc_node(
-            String::from_utf8(ddn_id.clone()).unwrap(),
-            String::from("https://localhost"),
-        )
-        .unwrap();
+    let p2p_id = String::from_utf8(ddn_id.clone()).unwrap();
+    let url = String::from("test_url");
+
+    contract.add_ddc_node(p2p_id, url).unwrap();
 
     contract.add_reporter(accounts.alice).unwrap();
     contract

--- a/cere02/lib.rs
+++ b/cere02/lib.rs
@@ -605,7 +605,16 @@ mod ddc {
                 None => panic!("DDN not found"),
             };
 
-            let now = Self::env().block_timestamp();
+            // let now = Self::env().block_timestamp();
+
+            // REMOVE: Eve account balance is used as timestamp in tests ¯\_(ツ)_/¯
+            let now: u64 = match Self::env().block_timestamp() {
+                0 => ink_env::test::get_account_balance::<ink_env::DefaultEnvironment>(
+                    AccountId::from([0x05; 32]),
+                )
+                .unwrap() as u64,
+                _ => Self::env().block_timestamp(),
+            };
 
             if !ddn_status.is_online {
                 let last_downtime = now - ddn_status.last_timestamp;

--- a/cere02/lib.rs
+++ b/cere02/lib.rs
@@ -602,7 +602,7 @@ mod ddc {
 
             let ddn_status = match self.ddn_statuses.get_mut(&p2p_id) {
                 Some(ddn_status) => ddn_status,
-                None => panic!("DDN not found"),
+                None => return Err(Error::DDNNotFound),
             };
 
             let now = Self::env().block_timestamp();
@@ -619,13 +619,13 @@ mod ddc {
         }
 
         #[ink(message)]
-        pub fn get_ddn_status(&self, p2p_id: String) -> DDNStatus {
+        pub fn get_ddn_status(&self, p2p_id: String) -> Result<DDNStatus> {
             let ddn_status = match self.ddn_statuses.get(&p2p_id) {
                 Some(ddn_status) => ddn_status.clone(),
-                None => panic!("DDN not found"),
+                None => return Err(Error::DDNNotFound),
             };
 
-            ddn_status
+            Ok(ddn_status)
         }
     }
 
@@ -951,6 +951,7 @@ mod ddc {
         ContractActive,
         UnexpectedTimestamp,
         NoSubscription,
+        DDNNotFound,
     }
 
     pub type Result<T> = core::result::Result<T, Error>;

--- a/cere02/lib.rs
+++ b/cere02/lib.rs
@@ -605,16 +605,7 @@ mod ddc {
                 None => panic!("DDN not found"),
             };
 
-            // let now = Self::env().block_timestamp();
-
-            // REMOVE: Eve account balance is used as timestamp in tests ¯\_(ツ)_/¯
-            let now: u64 = match Self::env().block_timestamp() {
-                0 => ink_env::test::get_account_balance::<ink_env::DefaultEnvironment>(
-                    AccountId::from([0x05; 32]),
-                )
-                .unwrap() as u64,
-                _ => Self::env().block_timestamp(),
-            };
+            let now = Self::env().block_timestamp();
 
             if !ddn_status.is_online {
                 let last_downtime = now - ddn_status.last_timestamp;

--- a/cere02/lib.rs
+++ b/cere02/lib.rs
@@ -597,6 +597,7 @@ mod ddc {
     }
 
     impl Ddc {
+        // Private function to set DDN status (used in tests)
         fn set_ddn_status(&mut self, p2p_id: String, now: u64, is_online: bool) -> Result<()> {
             let ddn_status = match self.ddn_statuses.get_mut(&p2p_id) {
                 Some(ddn_status) => ddn_status,
@@ -618,6 +619,9 @@ mod ddc {
             Ok(())
         }
 
+        /// Update DDC node connectivity status (online/offline)
+        /// Called by OCW to set DDN offline status if fetching of node metrics failed
+        /// Called by SC to set online status when metrics is reported
         #[ink(message)]
         pub fn report_ddn_status(&mut self, p2p_id: String, is_online: bool) -> Result<()> {
             let reporter = self.env().caller();
@@ -628,6 +632,7 @@ mod ddc {
             self.set_ddn_status(p2p_id, now, is_online)
         }
 
+        /// Get DDC node status
         #[ink(message)]
         pub fn get_ddn_status(&self, p2p_id: String) -> Result<DDNStatus> {
             let ddn_status = match self.ddn_statuses.get(&p2p_id) {
@@ -871,6 +876,9 @@ mod ddc {
             Ok(())
         }
 
+        /// Reports DDC node metrics
+        /// Called by OCW if node metrics is successfully fetched
+        /// Updates DDC node connectivity status to online
         #[ink(message)]
         pub fn report_metrics_ddn(
             &mut self,

--- a/cere02/lib.rs
+++ b/cere02/lib.rs
@@ -538,16 +538,18 @@ mod ddc {
             let caller = self.env().caller();
             self.only_owner(caller)?;
 
-            let now = Self::env().block_timestamp();
-            self.ddn_statuses.insert(
-                p2p_id.clone(),
-                DDNStatus {
-                    is_online: true,
-                    total_downtime: 0,
-                    reference_timestamp: now,
-                    last_timestamp: now,
-                },
-            );
+            if !self.ddn_statuses.contains_key(&p2p_id) {
+                let now = Self::env().block_timestamp();
+                self.ddn_statuses.insert(
+                    p2p_id.clone(),
+                    DDNStatus {
+                        is_online: true,
+                        total_downtime: 0,
+                        reference_timestamp: now,
+                        last_timestamp: now,
+                    },
+                );
+            }
 
             self.ddc_nodes.insert(
                 p2p_id.clone(),
@@ -601,7 +603,7 @@ mod ddc {
                 None => return Err(Error::DDNNotFound),
             };
 
-            if now < ddn_status.last_timestamp {
+            if now < ddn_status.last_timestamp || now < ddn_status.reference_timestamp {
                 return Err(Error::UnexpectedTimestamp);
             }
 


### PR DESCRIPTION
New method should be implemented for status to be reported
>   `report_ddn_status` should be called only by the reporter

```rust
fn report_ddn_status(ddn_id: String, status: StatusEnum) -> Result<()>

enum StatusEnum {Offline, Online}
```

Aggregated statuses should be stored for each DDN:

```rust
pub ddn_statuses: StorageHashMap<p2p_id: String, DDNStatus>

DDNStatus: {
  is_online: bool,
  total_downtime: u64,
  reference_timestamp: u64,
  last_timestamp: u64,
}
```

New method should be implemented to get status:
```rust
fn get_ddn_status(p2p_id: String) -> DDNStatus
```

Method `report_metrics_ddn` should trigger the `report_ddn_status` method anytime it receives the DDN data.